### PR TITLE
Updating to ow-electron 19.1.3-1

### DIFF
--- a/wowup-electron/package.json
+++ b/wowup-electron/package.json
@@ -107,7 +107,7 @@
     "@microsoft/applicationinsights-web": "2.8.8",
     "@ngx-translate/core": "14.0.0",
     "@ngx-translate/http-loader": "7.0.0",
-    "@overwolf/ow-electron": "19.1.3",
+    "@overwolf/ow-electron": "19.1.3-1",
     "@overwolf/ow-electron-builder": "23.4.1",
     "@types/adm-zip": "0.5.0",
     "@types/archiver": "5.3.1",


### PR DESCRIPTION
Fixes a rare bug where due to a hidden CMP window being closed on startup, a race condition would auto close the entire app
