### PR TITLE
updating to ow-electron 19.1.8-1

### DIFF
--- a/wowup-electron/package.json
+++ b/wowup-electron/package.json
@@ -108,7 +108,7 @@
     "@microsoft/applicationinsights-web": "2.8.9",
     "@ngx-translate/core": "14.0.0",
     "@ngx-translate/http-loader": "7.0.0",
-    "@overwolf/ow-electron": "19.1.3-1",
+    "@overwolf/ow-electron": "19.1.8-1",
     "@overwolf/ow-electron-builder": "23.4.1",
     "@types/adm-zip": "0.5.0",
     "@types/archiver": "5.3.1",


### PR DESCRIPTION
Fixing the ads memory leaks.
This is a two step solution - first we need to upgrade to this latest ow-electron version. Secondly, we'll turn on the ads part of the fix.

Thanks