### PR TITLE
Fix API_URL for github

### DIFF
--- a/wowup-electron/src/app/addon-providers/github-addon-provider.ts
+++ b/wowup-electron/src/app/addon-providers/github-addon-provider.ts
@@ -56,7 +56,7 @@ interface ReleaseMetaItemMetadata {
   interface: number;
 }
 
-const API_URL = "https://api.com/repos";
+const API_URL = "https://api.github.com/repos";
 const RELEASE_CONTENT_TYPES = {
   XZIP: "application/x-zip-compressed",
   ZIP: "application/zip",


### PR DESCRIPTION
idk who did this, but it broke github imports.. it's correct on the WAGO Version of WoWUP still.. so someone broke the url only on CF version.